### PR TITLE
fix(Session): Send cookie header only when session has been used

### DIFF
--- a/src/PsrApplication.php
+++ b/src/PsrApplication.php
@@ -68,7 +68,9 @@ class PsrApplication
 		private Session $session,
 	) {
 		$this->onResponse[] = function () {
-			$this->session->sendCookie();
+			if($this->session->isStarted()){
+				$this->session->sendCookie();
+			}
 			$this->session->close();
 
 			if (!$this->httpRequest->getCookie(Helpers::STRICT_COOKIE_NAME)) {


### PR DESCRIPTION
This should prevent sending Set-Cookie header with empty SESSIONID value and should solve https://github.com/mallgroup/roadrunner/issues/13