### PR TITLE
fix(Session): Allow setting handler only before session start

### DIFF
--- a/src/Http/Session.php
+++ b/src/Http/Session.php
@@ -38,7 +38,6 @@ class Session extends \Nette\Http\Session
 	/** @deprecated */
 	protected bool $readAndClose = false;
 	protected bool $autoStart = true;
-	private SessionHandlerInterface|null $handler = null;
 	private bool $configured = false;
 
 	public function __construct(
@@ -109,9 +108,6 @@ class Session extends \Nette\Http\Session
 			}
 		}
 
-		if ($this->handler) {
-			session_set_save_handler($this->handler);
-		}
 		$this->configured = true;
 	}
 
@@ -279,10 +275,10 @@ class Session extends \Nette\Http\Session
 	 */
 	public function setHandler(\SessionHandlerInterface $handler): static
 	{
-		if ($this->configured) {
-			throw new Nette\InvalidStateException('Unable to set handler when session has been configured.');
+		if ($this->isStarted()) {
+			throw new Nette\InvalidStateException('Unable to set handler when session has been started.');
 		}
-		$this->handler = $handler;
+		session_set_save_handler($handler);
 		return $this;
 	}
 


### PR DESCRIPTION
Calling Session::setOptions, Session::setCookieParameters or any other method that is calling configure method internally results to `ErrorException: Warning: session_set_save_handler(): Cannot change save handler when session is active`

This PR should fix that, and is good addition to: https://github.com/mallgroup/roadrunner/issues/13