### PR TITLE
fix(Extension): fix init cookie on response setup

### DIFF
--- a/src/DI/Extension.php
+++ b/src/DI/Extension.php
@@ -184,11 +184,11 @@ class Extension extends Nette\DI\CompilerExtension
 			->setAutowired(NetteApplicationHandler::class)
 			->addSetup('$catchExceptions', [$this->config->catchExceptions])
 			->addSetup('$errorPresenter', [$this->config->errorPresenter])
-			->addSetup('$onResponse[] = ?', [
-				(string)(new Nette\PhpGenerator\Literal(
-					'function() { Nette\Http\Helpers::initCookie($this->getService(?), $this->getService(?));};',
-					[$this->prefix('response'), $this->prefix('request')]
-				))
+			->addSetup('$onResponse[]', [
+				new Nette\PhpGenerator\Literal(
+					'function(): void { Nette\Http\Helpers::initCookie($this->getService(?), $this->getService(?));}',
+					[$this->prefix('request'), $this->prefix('response')]
+				)
 			]);
 	}
 


### PR DESCRIPTION
i was solving issue of nette forms notworking

i found the NetteApplicationHandler setup to be broken
Nette DI generates code which does not add initCookie to onResponse

this fixes this issue